### PR TITLE
Patched API to specs

### DIFF
--- a/www/fido.js
+++ b/www/fido.js
@@ -1,49 +1,76 @@
 var exec = require('cordova/exec');
 
+
+/**
+ * Temporary variables
+ */
+
+/**
+ * In the DOM API, the browser or browser plugin is responsible for supplying any available channel binding information to the FIDO Client.
+ * So this is temporary global polyfill
+ * @type {Object}
+ */
+var channelBindings = {
+    "serverEndPoint" : null,
+    "tlsServerCertificate" : null,
+    "tlsUnique" : null,
+    "cid_pubkey" : null
+};
+
+/**
+ * Same here
+ * @type {String}
+ */
+var origin = "https://example.com/"
+
 /**
  * These functions are basically convenience functions for cordova.exec()
  * They bind to the 'clobbers' target defined in the plugin.xml file, such that
  * uafDiscover() becomes fido.uafDiscover() in the Cordova application
  */ 
 var fido = {
-    uafDiscover: function() {
-        return new Promise(function(resolve, reject) {
-            exec(
-                function(ret) { // success
-                    resolve (ret);
-                },
-                function(err) { // error
-                    reject (err);
-                }, "fido", "uafDiscover", []);
-        });
-    },
+    uaf : {
+        discover: function() {
+            return new Promise(function(resolve, reject) {
+                exec(
+                    resolve, // success
+                    reject,  // fail
+                    "fido",
+                    "uafDiscover",
+                    []
+                );
+            });
+        },
 
-    uafCheckPolicy: function(message, origin) {
-        return new Promise(function(resolve, reject) {
-            exec(
-                function(ret) { // success
-                    resolve (ret);
-                },
-                function(err) { // error
-                    reject (err);
-                }, "fido", "uafCheckPolicy", [message, origin]);
-        });
-    },
+        checkPolicy: function(message) {
+            return new Promise(function(resolve, reject) {
+                exec(
+                    resolve, // success
+                    reject,  // fail
+                    "fido",
+                    "uafCheckPolicy",
+                    [ message, origin ]
+                );
+            });
+        },
 
-    uafOperation: function(message, channelBindings, origin) {
-        return new Promise(function(resolve, reject) {
-            exec(
-                function(ret) { // success
-                    resolve (ret);
-                },
-                function(err) { // error
-                    reject (err);
-                }, "fido", "uafOperation", [ // args
-                    {uafProtocolMessage: JSON.stringify(message), additionalData: {}}, // XXX note that we are modifying the first argument here to uafMessage format. not sure if this belongs here, or in the Java code
-                    channelBindings, 
-                    origin
-                ]);
-        });
+        processUAFOperation: function(message) {
+            return new Promise(function(resolve, reject) {
+                exec(
+                    resolve, // success
+                    reject,  // fail
+                    "fido",
+                    "uafOperation",
+                    [ message, channelBindings, origin ]
+                );
+            });
+        },
+
+        notifyUAFResult: function(responseCode) {
+            return new Promise(function(resolve, reject) {
+                // TODO Implement notifyUAFResult (int responseCode, UAFMessage uafResponse);
+            });
+        }
     }
 };
 

--- a/www/fido.js
+++ b/www/fido.js
@@ -60,7 +60,9 @@ var fido = {
         processUAFOperation: function(message) {
             return new Promise(function(resolve, reject) {
                 exec(
-                    resolve, // success
+                    (data) => {
+                        resolve(JSON.parse(data))
+                    }, // success
                     reject,  // fail
                     "fido",
                     "uafOperation",

--- a/www/fido.js
+++ b/www/fido.js
@@ -45,7 +45,10 @@ var fido = {
         checkPolicy: function(message) {
             return new Promise(function(resolve, reject) {
                 exec(
-                    resolve, // success
+                    /**
+                     * checkPolicy must always return exception. The only difference is status code.
+                     */
+                    reject, // success
                     reject,  // fail
                     "fido",
                     "uafCheckPolicy",


### PR DESCRIPTION
Added temporary global variable channelBindings, as it is up to app to DOM API to provide this info.

Same done to origin

Moved all the functions into fido.uaf object, and renamed according to specs.

Replaced function(ans){reject/resolve(ret)} with just reject/resolve as they are anyway functions them self.

Removed {uafProtocolMessage: JSON.stringify(message), additionalData: {}}, as this is callers job to generate such message

Added  notifyUAFResult placeholder.

Made things pretty.
